### PR TITLE
remove kwargs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Use the [Passkit::UrlGenerator](lib/passkit/url_generator.rb) to generate the UR
 You can initialize it with:
 
 ```ruby
-Passkit::UrlGenerator.new(pass_class: Passkit::MyPass, generator: User.find(1))
+Passkit::UrlGenerator.new(Passkit::MyPass, User.find(1))
 ```
 
 and then use `.android` or `.ios` to get the URL to serve the Wallet Pass.


### PR DESCRIPTION
Hi! This one briefly tripped me up a little since it expands to a hash and the error was a bit confusing, hah. Just updates the README to use arguments instead of kwargs.

(Also, thanks for open sourcing this! I was halfway through my own hastily-put-together solution for PassKit, and this is a great framework for the approximately three of us left who generate passes for devices these days. Seriously, literally all the docs on anything related to this are from like, 2012. Anyway, will likely contribute some more back to this as we build out our solution!)