### PR TITLE
Allow labelColor to be defined

### DIFF
--- a/app/models/passkit/pass.rb
+++ b/app/models/passkit/pass.rb
@@ -14,6 +14,7 @@ module Passkit
       :apple_team_identifier,
       :foreground_color,
       :background_color,
+      :label_color,
       :web_service_url,
       :barcode,
       :voided,

--- a/lib/passkit/base_pass.rb
+++ b/lib/passkit/base_pass.rb
@@ -52,6 +52,10 @@ module Passkit
       "rgb(255, 255, 255)"
     end
 
+    def label_color
+      "rgb(255, 255, 255)"
+    end
+
     def organization_name
       "Passkit"
     end

--- a/lib/passkit/generator.rb
+++ b/lib/passkit/generator.rb
@@ -55,7 +55,8 @@ module Passkit
         organizationName: @pass.organization_name,
         description: @pass.description,
         logoText: @pass.logo_text,
-        locations: @pass.locations
+        locations: @pass.locations,
+        labelColor: @pass.label_color
       }
 
       pass = pass.merge({


### PR DESCRIPTION
`labelColor` [can be defined](https://developer.apple.com/library/archive/documentation/UserExperience/Reference/PassKit_Bundle/Chapters/TopLevel.html#//apple_ref/doc/uid/TP40012026-CH2-SW5) at the top-level to, you know, set the color of labels.