### PR TITLE
Move validation until after the block is called

### DIFF
--- a/lib/passkit.rb
+++ b/lib/passkit.rb
@@ -18,6 +18,7 @@ module Passkit
   def self.configure
     self.configuration ||= Configuration.new
     yield(configuration) if block_given?
+    configuration.validate!
   end
 
   class Configuration
@@ -41,13 +42,22 @@ module Passkit
 
     def initialize
       @available_passes = {"Passkit::ExampleStoreCard" => -> {}}
-      @web_service_host = ENV["PASSKIT_WEB_SERVICE_HOST"] || (raise "Please set PASSKIT_WEB_SERVICE_HOST")
+      @web_service_host = ENV["PASSKIT_WEB_SERVICE_HOST"]
+      @certificate_key = ENV["PASSKIT_CERTIFICATE_KEY"]
+      @private_p12_certificate = ENV["PASSKIT_PRIVATE_P12_CERTIFICATE"]
+      @apple_intermediate_certificate = ENV["PASSKIT_APPLE_INTERMEDIATE_CERTIFICATE"]
+      @apple_team_identifier = ENV["PASSKIT_APPLE_TEAM_IDENTIFIER"]
+      @pass_type_identifier = ENV["PASSKIT_PASS_TYPE_IDENTIFIER"]
+    end
+
+    def validate!
+      raise "Please set PASSKIT_WEB_SERVICE_HOST" unless web_service_host
       raise("PASSKIT_WEB_SERVICE_HOST must start with https://") unless @web_service_host.start_with?("https://")
-      @certificate_key = ENV["PASSKIT_CERTIFICATE_KEY"] || (raise "Please set PASSKIT_CERTIFICATE_KEY")
-      @private_p12_certificate = ENV["PASSKIT_PRIVATE_P12_CERTIFICATE"] || (raise "Please set PASSKIT_PRIVATE_P12_CERTIFICATE")
-      @apple_intermediate_certificate = ENV["PASSKIT_APPLE_INTERMEDIATE_CERTIFICATE"] || (raise "Please set PASSKIT_APPLE_INTERMEDIATE_CERTIFICATE")
-      @apple_team_identifier = ENV["PASSKIT_APPLE_TEAM_IDENTIFIER"] || (raise "Please set PASSKIT_APPLE_TEAM_IDENTIFIER")
-      @pass_type_identifier = ENV["PASSKIT_PASS_TYPE_IDENTIFIER"] || (raise "Please set PASSKIT_PASS_TYPE_IDENTIFIER")
+      raise "Please set PASSKIT_CERTIFICATE_KEY" unless certificate_key
+      raise "Please set PASSKIT_PRIVATE_P12_CERTIFICATE" unless private_p12_certificate
+      raise "Please set PASSKIT_APPLE_INTERMEDIATE_CERTIFICATE" unless apple_intermediate_certificate
+      raise "Please set PASSKIT_APPLE_TEAM_IDENTIFIER" unless apple_team_identifier
+      raise "Please set PASSKIT_PASS_TYPE_IDENTIFIER" unless pass_type_identifier
     end
   end
 end

--- a/lib/passkit.rb
+++ b/lib/passkit.rb
@@ -60,7 +60,7 @@ module Passkit
       raise("PASSKIT_WEB_SERVICE_HOST must start with https://") unless web_service_host.start_with?("https://")
 
       if wwdc_cert
-        intermediate_certificate = OpenSSL::X509::Certificate.new(File.read(Rails.root_join(wwdc_cert)))
+        intermediate_certificate = OpenSSL::X509::Certificate.new(File.read(Rails.root.join(wwdc_cert)))
       else
         raise "Please set PASSKIT_WWDC_CERT"
       end
@@ -69,10 +69,10 @@ module Passkit
       raise "Please set PASSKIT_P12_PASSWORD" unless p12_password
 
       if p12_key
-        key = OpenSSL::PKey::RSA.new(p12_key, p12_password)
-        cert = OpenSSL::X509::Certificate.new(p12_certificate)
+        key = OpenSSL::PKey::RSA.new(File.read(Rails.root.join(p12_key)), p12_password)
+        cert = OpenSSL::X509::Certificate.new(File.read(Rails.root.join(p12_certificate)))
       else
-        p12_certificate = OpenSSL::PKCS12.new(File.read(Rails.root.join(Passkit.configuration.p12_certificate)), Passkit.configuration.p12_password)
+        p12_certificate = OpenSSL::PKCS12.new(File.read(Rails.root.join(p12_certificate)), p12_password)
         key = p12_certificate.key
         cert = p12_certificate.certificate
       end

--- a/lib/passkit.rb
+++ b/lib/passkit.rb
@@ -24,9 +24,10 @@ module Passkit
   class Configuration
     attr_accessor :available_passes,
       :web_service_host,
-      :certificate_key,
-      :private_p12_certificate,
-      :apple_intermediate_certificate,
+      :p12_password,
+      :p12_certificate,
+      :p12_key,
+      :wwdc_cert,
       :apple_team_identifier,
       :pass_type_identifier,
       :format_version,
@@ -45,9 +46,10 @@ module Passkit
     def initialize
       @available_passes = {"Passkit::ExampleStoreCard" => -> {}}
       @web_service_host = ENV["PASSKIT_WEB_SERVICE_HOST"]
-      @certificate_key = ENV["PASSKIT_CERTIFICATE_KEY"]
-      @private_p12_certificate = ENV["PASSKIT_PRIVATE_P12_CERTIFICATE"]
-      @apple_intermediate_certificate = ENV["PASSKIT_APPLE_INTERMEDIATE_CERTIFICATE"]
+      @p12_password = ENV["PASSKIT_P12_PASSWORD"] || ENV["PASSKIT_CERTIFICATE_KEY"]
+      @p12_certificate = ENV["PASSKIT_P12_CERTIFICATE"] || ENV["PASSKIT_PRIVATE_P12_CERTIFICATE"]
+      @p12_key = ENV["PASSKIT_P12_KEY"]      
+      @wwdc_cert = ENV["PASSKIT_WWDC_CERT"] || ENV["PASSKIT_APPLE_INTERMEDIATE_CERTIFICATE"]
       @apple_team_identifier = ENV["PASSKIT_APPLE_TEAM_IDENTIFIER"]
       @pass_type_identifier = ENV["PASSKIT_PASS_TYPE_IDENTIFIER"]
       @format_version = ENV["PASSKIT_FORMAT_VERSION"] || 1
@@ -55,10 +57,29 @@ module Passkit
 
     def validate!
       raise "Please set PASSKIT_WEB_SERVICE_HOST" unless web_service_host
-      raise("PASSKIT_WEB_SERVICE_HOST must start with https://") unless @web_service_host.start_with?("https://")
-      raise "Please set PASSKIT_CERTIFICATE_KEY" unless certificate_key
-      raise "Please set PASSKIT_PRIVATE_P12_CERTIFICATE" unless private_p12_certificate
-      raise "Please set PASSKIT_APPLE_INTERMEDIATE_CERTIFICATE" unless apple_intermediate_certificate
+      raise("PASSKIT_WEB_SERVICE_HOST must start with https://") unless web_service_host.start_with?("https://")
+
+      if wwdc_cert
+        intermediate_certificate = OpenSSL::X509::Certificate.new(File.read(Rails.root_join(wwdc_cert)))
+      else
+        raise "Please set PASSKIT_WWDC_CERT"
+      end
+
+      raise "Please set PASSKIT_P12_CERTIFICATE" unless p12_certificate
+      raise "Please set PASSKIT_P12_PASSWORD" unless p12_password
+
+      if p12_key
+        key = OpenSSL::PKey::RSA.new(p12_key, p12_password)
+        cert = OpenSSL::X509::Certificate.new(p12_certificate)
+      else
+        p12_certificate = OpenSSL::PKCS12.new(File.read(Rails.root.join(Passkit.configuration.p12_certificate)), Passkit.configuration.p12_password)
+        key = p12_certificate.key
+        cert = p12_certificate.certificate
+      end
+
+      flag = OpenSSL::PKCS7::DETACHED | OpenSSL::PKCS7::BINARY
+      OpenSSL::PKCS7.sign(cert, key, 'test', [intermediate_certificate], flag) # If this runs, all good
+
       raise "Please set PASSKIT_APPLE_TEAM_IDENTIFIER" unless apple_team_identifier
       raise "Please set PASSKIT_PASS_TYPE_IDENTIFIER" unless pass_type_identifier
     end

--- a/lib/passkit.rb
+++ b/lib/passkit.rb
@@ -28,16 +28,18 @@ module Passkit
       :private_p12_certificate,
       :apple_intermediate_certificate,
       :apple_team_identifier,
-      :pass_type_identifier
+      :pass_type_identifier,
+      :format_version,
+      :dashboard_username,
+      :dashboard_password
 
-    DEFAULT_AUTHENTICATION = proc do
-      authenticate_or_request_with_http_basic("Passkit Dashboard. Login required") do |username, password|
-        username == ENV["PASSKIT_DASHBOARD_USERNAME"] && password == ENV["PASSKIT_DASHBOARD_PASSWORD"]
-      end
-    end
     def authenticate_dashboard_with(&block)
       @authenticate = block if block
-      @authenticate || DEFAULT_AUTHENTICATION
+      @authenticate || proc do
+        authenticate_or_request_with_http_basic("Passkit Dashboard. Login required") do |username, password|
+          username == dashboard_username && password == dashboard_password
+        end
+      end
     end
 
     def initialize
@@ -48,6 +50,7 @@ module Passkit
       @apple_intermediate_certificate = ENV["PASSKIT_APPLE_INTERMEDIATE_CERTIFICATE"]
       @apple_team_identifier = ENV["PASSKIT_APPLE_TEAM_IDENTIFIER"]
       @pass_type_identifier = ENV["PASSKIT_PASS_TYPE_IDENTIFIER"]
+      @format_version = ENV["PASSKIT_FORMAT_VERSION"] || 1
     end
 
     def validate!

--- a/lib/passkit/base_pass.rb
+++ b/lib/passkit/base_pass.rb
@@ -5,15 +5,15 @@ module Passkit
     end
 
     def format_version
-      ENV["PASSKIT_FORMAT_VERSION"] || 1
+      Passkit.configuration.format_version
     end
 
     def apple_team_identifier
-      ENV["PASSKIT_APPLE_TEAM_IDENTIFIER"] || raise(Error.new("Missing environment variable: PASSKIT_APPLE_TEAM_IDENTIFIER"))
+      Passkit.configuration.apple_team_identifier
     end
 
     def pass_type_identifier
-      ENV["PASSKIT_PASS_TYPE_IDENTIFIER"] || raise(Error.new("Missing environment variable: PASSKIT_PASS_TYPE_IDENTIFIER"))
+      Passkit.configuration.pass_type_identifier
     end
 
     def language
@@ -40,8 +40,7 @@ module Passkit
     end
 
     def web_service_url
-      raise Error.new("Missing environment variable: PASSKIT_WEB_SERVICE_HOST") unless ENV["PASSKIT_WEB_SERVICE_HOST"]
-      "#{ENV["PASSKIT_WEB_SERVICE_HOST"]}/passkit/api"
+      "#{Passkit.configuration.web_service_host}/passkit/api"
     end
 
     def foreground_color

--- a/lib/passkit/generator.rb
+++ b/lib/passkit/generator.rb
@@ -92,8 +92,8 @@ module Passkit
       intermediate_certificate = OpenSSL::X509::Certificate.new(File.read(Rails.root.join(Passkit.configuration.wwdc_cert)))
 
       if Passkit.configuration.p12_key
-        key = OpenSSL::PKey::RSA.new(Passkit.configuration.p12_key, Passkit.configuration.p12_password)
-        cert = OpenSSL::X509::Certificate.new(Passkit.configuration.p12_certificate)
+        key = OpenSSL::PKey::RSA.new(File.read(Rails.root.join(Passkit.configuration.p12_key)), Passkit.configuration.p12_password)
+        cert = OpenSSL::X509::Certificate.new(File.read(Rails.root.join(Passkit.configuration.p12_certificate)))
       else
         p12_certificate = OpenSSL::PKCS12.new(File.read(Rails.root.join(Passkit.configuration.p12_certificate)), Passkit.configuration.p12_password)
         key = p12_certificate.key

--- a/lib/passkit/generator.rb
+++ b/lib/passkit/generator.rb
@@ -87,14 +87,10 @@ module Passkit
       File.write(@manifest_url, manifest.to_json)
     end
 
-    CERTIFICATE = Rails.root.join(ENV["PASSKIT_PRIVATE_P12_CERTIFICATE"])
-    INTERMEDIATE_CERTIFICATE = Rails.root.join(ENV["PASSKIT_APPLE_INTERMEDIATE_CERTIFICATE"])
-    CERTIFICATE_PASSWORD = ENV["PASSKIT_CERTIFICATE_KEY"]
-
     # :nocov:
     def sign_manifest
-      p12_certificate = OpenSSL::PKCS12.new(File.read(CERTIFICATE), CERTIFICATE_PASSWORD)
-      intermediate_certificate = OpenSSL::X509::Certificate.new(File.read(INTERMEDIATE_CERTIFICATE))
+      p12_certificate = OpenSSL::PKCS12.new(Rails.root.join(Passkit.configuration.private_p12_certificate), Passkit.configuration.certificate_key)
+      intermediate_certificate = OpenSSL::X509::Certificate.new(File.read(Rails.root.join(Passkit.configuration.apple_intermediate_certificate)))
 
       flag = OpenSSL::PKCS7::DETACHED | OpenSSL::PKCS7::BINARY
       signed = OpenSSL::PKCS7.sign(p12_certificate.certificate,

--- a/lib/passkit/generator.rb
+++ b/lib/passkit/generator.rb
@@ -89,7 +89,7 @@ module Passkit
 
     # :nocov:
     def sign_manifest
-      p12_certificate = OpenSSL::PKCS12.new(Rails.root.join(Passkit.configuration.private_p12_certificate), Passkit.configuration.certificate_key)
+      p12_certificate = OpenSSL::PKCS12.new(File.read(Rails.root.join(Passkit.configuration.private_p12_certificate)), Passkit.configuration.certificate_key)
       intermediate_certificate = OpenSSL::X509::Certificate.new(File.read(Rails.root.join(Passkit.configuration.apple_intermediate_certificate)))
 
       flag = OpenSSL::PKCS7::DETACHED | OpenSSL::PKCS7::BINARY

--- a/lib/passkit/url_generator.rb
+++ b/lib/passkit/url_generator.rb
@@ -3,7 +3,7 @@ module Passkit
     include Passkit::Engine.routes.url_helpers
 
     def initialize(pass_class, generator = nil)
-      @url = passes_api_url(host: ENV["PASSKIT_WEB_SERVICE_HOST"],
+      @url = passes_api_url(host: Passkit.configuration.web_service_host,
         payload: PayloadGenerator.encrypted(pass_class, generator))
     end
 

--- a/test/api/v1/test_passes_controller.rb
+++ b/test/api/v1/test_passes_controller.rb
@@ -21,15 +21,15 @@ class TestPassesController < ActionDispatch::IntegrationTest
     _pkpass = Passkit::Factory.create_pass(Passkit::ExampleStoreCard)
     assert_equal 1, Passkit::Pass.count
     pass = Passkit::Pass.last
-    get pass_path(pass_type_id: ENV["PASSKIT_PASS_TYPE_IDENTIFIER"], serial_number: pass.serial_number)
+    get pass_path(pass_type_id: Passkit.configuration.pass_type_identifier, serial_number: pass.serial_number)
     assert_response :unauthorized
 
-    get pass_path(pass_type_id: ENV["PASSKIT_PASS_TYPE_IDENTIFIER"], serial_number: pass.serial_number),
+    get pass_path(pass_type_id: Passkit.configuration.pass_type_identifier, serial_number: pass.serial_number),
       headers: {"Authorization" => "ApplePass #{pass.authentication_token}"}
 
     assert_response :success
 
-    get pass_path(pass_type_id: ENV["PASSKIT_PASS_TYPE_IDENTIFIER"], serial_number: pass.serial_number),
+    get pass_path(pass_type_id: Passkit.configuration.pass_type_identifier, serial_number: pass.serial_number),
       headers: {"Authorization" => "ApplePass #{pass.authentication_token}", "If-Modified-Since" => Time.zone.now.httpdate}
 
     assert_equal "", response.body

--- a/test/system/logs_dashboard_test.rb
+++ b/test/system/logs_dashboard_test.rb
@@ -8,7 +8,7 @@ class LogsDashboardTest < ActionDispatch::SystemTestCase
   end
 
   def authorize
-    visit "http://#{ENV["PASSKIT_DASHBOARD_USERNAME"]}:#{ENV["PASSKIT_DASHBOARD_PASSWORD"]}@#{Capybara.current_session.server.host}:#{Capybara.current_session.server.port}/passkit/dashboard/logs"
+    visit "http://#{Passkit.configuration.dashboard_username}:#{Passkit.configuration.dashboard_password}@#{Capybara.current_session.server.host}:#{Capybara.current_session.server.port}/passkit/dashboard/logs"
   end
 
   test "visiting the logs dashboard" do


### PR DESCRIPTION
For those of us who prefer to use `Rails.application.credentials` to `ENV`

This would allow for config setting being done like:

```ruby
Passkit.configure do |config|
  config.web_service_host = Rails.application.credentials.passkit_web_service_host
  config.certificate_key = Rails.application.credentials.passkit_certificate_key
  // etc...
end
```