### PR TITLE
Remove uniqueness on pushToken

### DIFF
--- a/app/models/passkit/device.rb
+++ b/app/models/passkit/device.rb
@@ -1,7 +1,6 @@
 module Passkit
   class Device < ActiveRecord::Base
     validates_uniqueness_of :identifier
-    validates_uniqueness_of :push_token
 
     has_many :registrations, foreign_key: :passkit_device_id
     has_many :passes, through: :registrations


### PR DESCRIPTION
We want to allow duplicate push tokens because we actually receive them duplicate. Investigating why