### PR TITLE
Key pass update logic from Pass#last_update

### DIFF
--- a/app/controllers/passkit/api/v1/registrations_controller.rb
+++ b/app/controllers/passkit/api/v1/registrations_controller.rb
@@ -81,7 +81,7 @@ module Passkit
           passes = @device.passes
 
           if params[:passesUpdatedSince]&.present?
-            passes.all.filter { |a| a.generator.updated_at >= Date.parse(params[:passesUpdatedSince]) }
+            passes.all.filter { |a| a.last_update >= Date.parse(params[:passesUpdatedSince]) }
           else
             passes
           end


### PR DESCRIPTION
`Pass#last_update` is effectively the same thing (it runs through the generator and looks at the `updated_at` value), but by hardcoding that again here we can't overwrite the logic in our own `Pass` instances. This is helpful to have in the case of complex logic (i.e., not tied to a singular model) in a `Pass` that determines whether or not a user's pass should be updated or not.