### PR TITLE
Send appropriate headers on pass generation

### DIFF
--- a/app/controllers/passkit/api/v1/passes_controller.rb
+++ b/app/controllers/passkit/api/v1/passes_controller.rb
@@ -5,7 +5,7 @@ module Passkit
         before_action :decrypt_payload, only: :create
 
         def create
-          send_file(fetch_pass(@payload))
+          send_file(fetch_pass(@payload), type: 'application/vnd.apple.pkpass', disposition: 'attachment')
         end
 
         # @return If request is authorized, returns HTTP status 200 with a payload of the pass data.
@@ -29,7 +29,7 @@ module Passkit
           response.headers["last-modified"] = pass.last_update.strftime("%Y-%m-%d %H:%M:%S")
           if request.headers["If-Modified-Since"].nil? ||
               (pass.last_update.to_i > Time.zone.parse(request.headers["If-Modified-Since"]).to_i)
-            send_file(pass_output_path)
+            send_file(pass_output_path, type: 'application/vnd.apple.pkpass', disposition: 'attachment')
           else
             head :not_modified
           end


### PR DESCRIPTION
# Problem

In Chrome on iOS, passes download using the file download queue feature instead of prompting to install. Clicking on the download doesn't open the install prompt either. I have needed to text the file to myself using the Messages app to be able to install it.

![File](https://github.com/coorasse/passkit/assets/307888/e28fa306-8fa9-4372-8ba8-47f62028e292)

(Note: without this PR Safari works fine.)

# Solution

Send the `type: 'application/vnd.apple.pkpass'` in the controller response just like was done in https://github.com/coorasse/passkit/pull/14 for previews

# Notes

Verified that this works with both issuing and updating passes and does not impact the already working Safari behavior.