### PR TITLE
Configurable encryption key

### DIFF
--- a/lib/passkit/url_encrypt.rb
+++ b/lib/passkit/url_encrypt.rb
@@ -21,7 +21,8 @@ module Passkit
       private
 
       def encryption_key
-        Rails.application.secret_key_base[0..15]
+        key = ENV.fetch("PASSKIT_URL_ENCRYPTION_KEY") { Rails.application.secret_key_base }
+        key[0..15]
       end
 
       def cypher

--- a/lib/passkit/version.rb
+++ b/lib/passkit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Passkit
-  VERSION = "0.6.0"
+  VERSION = "0.6.0.1"
 end

--- a/lib/passkit/version.rb
+++ b/lib/passkit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Passkit
-  VERSION = "0.6.0.1"
+  VERSION = "0.6.1"
 end


### PR DESCRIPTION
Our security policies require us to use different encryption keys for different activities. This change allows the encryption key to be configured using an environment variable called `PASSKIT_URL_ENCRYPTION_KEY`. If that variable isn't set, then it falls back to using `Rails.application.secret_key_base`.