### PR TITLE
Visible labels

### DIFF
--- a/lib/passkit/base_pass.rb
+++ b/lib/passkit/base_pass.rb
@@ -48,14 +48,17 @@ module Passkit
     end
 
     def foreground_color
+      # black
       "rgb(0, 0, 0)"
     end
 
     def background_color
+      # white
       "rgb(255, 255, 255)"
     end
 
     def label_color
+      # black
       "rgb(0, 0, 0)"
     end
 

--- a/lib/passkit/base_pass.rb
+++ b/lib/passkit/base_pass.rb
@@ -56,7 +56,7 @@ module Passkit
     end
 
     def label_color
-      "rgb(255, 255, 255)"
+      "rgb(0, 0, 0)"
     end
 
     def organization_name


### PR DESCRIPTION
I would expect the labels to be visible by default.  Previously the label was white on white. 


I expect that this would prevent this misunderstanding. https://github.com/coorasse/passkit/issues/19