### PR TITLE
Optional configuration without environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ If you followed the installation steps, you already saw that Passkit provides
 you the tables and ActiveRecord models, and also an engine with the necessary APIs already implemented.
 
 Now is your turn. Before proceeding, you need to set these ENV variables:
+
 * `PASSKIT_WEB_SERVICE_HOST`
 * `PASSKIT_CERTIFICATE_KEY`
 * `PASSKIT_PRIVATE_P12_CERTIFICATE`
@@ -67,6 +68,26 @@ Now is your turn. Before proceeding, you need to set these ENV variables:
 
 We have a [specific guide on how to get all these](docs/passkit_environment_variables.md), please follow it.
 You cannot start using this library without these variables set, and we cannot do the work for you.
+
+Alternatively, you can configure passkit with an initializer, where you can use environment variables, Rails secrets,
+or any other source for the required credentials:
+
+```ruby
+Passkit.configure do |config|
+  # Required, no defaults
+  config.apple_team_identifier = "dummy ID"
+  config.certificate_key = "dummy key"
+  config.private_p12_certificate = "path/to/file"
+  config.apple_intermediate_certificate = "path/to/file"
+  config.pass_type_identifier = "pass.com.some.id"
+
+  # Optional, defaults shown
+  config.dashboard_username = nil
+  config.dashboard_password = nil
+  config.skip_verification = false # Unless true, throws exceptions on startup when a required configuration is missing
+  config.web_service_host = "https://localhost:3000"
+  config.available_passes = { "Passkit::ExampleStoreCard" => -> {} }
+end
 
 ## Usage
 

--- a/lib/passkit.rb
+++ b/lib/passkit.rb
@@ -18,6 +18,11 @@ module Passkit
   def self.configure
     self.configuration ||= Configuration.new
     yield(configuration) if block_given?
+    configuration.verify!
+  end
+
+  def self.configured?
+    self.configuration&.configured?
   end
 
   class Configuration
@@ -27,11 +32,24 @@ module Passkit
       :private_p12_certificate,
       :apple_intermediate_certificate,
       :apple_team_identifier,
-      :pass_type_identifier
+      :pass_type_identifier,
+      :dashboard_username,
+      :dashboard_password,
+      :format_version,
+      :skip_verification
+
+    REQUIRED_ATTRIBUTES = %i[
+      web_service_host
+      certificate_key
+      private_p12_certificate
+      apple_intermediate_certificate
+      apple_team_identifier
+      pass_type_identifier
+    ]
 
     DEFAULT_AUTHENTICATION = proc do
       authenticate_or_request_with_http_basic("Passkit Dashboard. Login required") do |username, password|
-        username == ENV["PASSKIT_DASHBOARD_USERNAME"] && password == ENV["PASSKIT_DASHBOARD_PASSWORD"]
+        username == Passkit.configuration.dashboard_username && password == Passkit.configuration.dashboard_password
       end
     end
     def authenticate_dashboard_with(&block)
@@ -40,14 +58,34 @@ module Passkit
     end
 
     def initialize
-      @available_passes = {"Passkit::ExampleStoreCard" => -> {}}
-      @web_service_host = ENV["PASSKIT_WEB_SERVICE_HOST"] || (raise "Please set PASSKIT_WEB_SERVICE_HOST")
-      raise("PASSKIT_WEB_SERVICE_HOST must start with https://") unless @web_service_host.start_with?("https://")
-      @certificate_key = ENV["PASSKIT_CERTIFICATE_KEY"] || (raise "Please set PASSKIT_CERTIFICATE_KEY")
-      @private_p12_certificate = ENV["PASSKIT_PRIVATE_P12_CERTIFICATE"] || (raise "Please set PASSKIT_PRIVATE_P12_CERTIFICATE")
-      @apple_intermediate_certificate = ENV["PASSKIT_APPLE_INTERMEDIATE_CERTIFICATE"] || (raise "Please set PASSKIT_APPLE_INTERMEDIATE_CERTIFICATE")
-      @apple_team_identifier = ENV["PASSKIT_APPLE_TEAM_IDENTIFIER"] || (raise "Please set PASSKIT_APPLE_TEAM_IDENTIFIER")
-      @pass_type_identifier = ENV["PASSKIT_PASS_TYPE_IDENTIFIER"] || (raise "Please set PASSKIT_PASS_TYPE_IDENTIFIER")
+      # Required
+      @certificate_key = ENV["PASSKIT_CERTIFICATE_KEY"]
+      @private_p12_certificate = ENV["PASSKIT_PRIVATE_P12_CERTIFICATE"]
+      @apple_intermediate_certificate = ENV["PASSKIT_APPLE_INTERMEDIATE_CERTIFICATE"]
+      @apple_team_identifier = ENV["PASSKIT_APPLE_TEAM_IDENTIFIER"]
+      @pass_type_identifier = ENV["PASSKIT_PASS_TYPE_IDENTIFIER"]
+
+      # Optional
+      @skip_verification = false
+      @web_service_host = ENV["PASSKIT_WEB_SERVICE_HOST"] || "https://localhost:3000"
+      @available_passes = { "Passkit::ExampleStoreCard" => -> {} }
+      @format_version = ENV["PASSKIT_FORMAT_VERSION"] || 1
+      @dashboard_username = ENV["PASSKIT_DASHBOARD_USERNAME"]
+      @dashboard_password = ENV["PASSKIT_DASHBOARD_PASSWORD"]
+    end
+
+    def configured?
+      REQUIRED_ATTRIBUTES.all? { |attr| send(attr).present? }
+    end
+
+    def verify!
+      return if skip_verification
+
+      REQUIRED_ATTRIBUTES.each do |attr|
+        raise Error, "Please set #{attr.upcase}" unless send(attr).present?
+      end
+
+      raise Error, "PASSKIT_WEB_SERVICE_HOST must start with https://" unless web_service_host.start_with?("https://")
     end
   end
 end

--- a/lib/passkit/base_pass.rb
+++ b/lib/passkit/base_pass.rb
@@ -5,15 +5,15 @@ module Passkit
     end
 
     def format_version
-      ENV["PASSKIT_FORMAT_VERSION"] || 1
+      Passkit.configuration.format_version
     end
 
     def apple_team_identifier
-      ENV["PASSKIT_APPLE_TEAM_IDENTIFIER"] || raise(Error.new("Missing environment variable: PASSKIT_APPLE_TEAM_IDENTIFIER"))
+      Passkit.configuration.apple_team_identifier
     end
 
     def pass_type_identifier
-      ENV["PASSKIT_PASS_TYPE_IDENTIFIER"] || raise(Error.new("Missing environment variable: PASSKIT_PASS_TYPE_IDENTIFIER"))
+      Passkit.configuration.pass_type_identifier
     end
 
     def language
@@ -43,8 +43,7 @@ module Passkit
     end
 
     def web_service_url
-      raise Error.new("Missing environment variable: PASSKIT_WEB_SERVICE_HOST") unless ENV["PASSKIT_WEB_SERVICE_HOST"]
-      "#{ENV["PASSKIT_WEB_SERVICE_HOST"]}/passkit/api"
+      "#{Passkit.configuration.web_service_host}/passkit/api"
     end
 
     # The foreground color, used for the values of fields shown on the front of the pass.

--- a/lib/passkit/generator.rb
+++ b/lib/passkit/generator.rb
@@ -111,8 +111,6 @@ module Passkit
       File.write(@temporary_path.join("pass.json"), pass.to_json)
     end
 
-    # rubocop:enable Metrics/AbcSize
-
     def generate_json_manifest
       manifest = {}
       Dir.glob(@temporary_path.join("**")).each do |file|
@@ -123,14 +121,18 @@ module Passkit
       File.write(@manifest_url, manifest.to_json)
     end
 
-    CERTIFICATE = Rails.root.join(ENV["PASSKIT_PRIVATE_P12_CERTIFICATE"])
-    INTERMEDIATE_CERTIFICATE = Rails.root.join(ENV["PASSKIT_APPLE_INTERMEDIATE_CERTIFICATE"])
-    CERTIFICATE_PASSWORD = ENV["PASSKIT_CERTIFICATE_KEY"]
+    def certificate_path
+      Rails.root.join(Passkit.configuration.private_p12_certificate)
+    end
+
+    def intermediate_certificate_path
+      Rails.root.join(Passkit.configuration.apple_intermediate_certificate)
+    end
 
     # :nocov:
     def sign_manifest
-      p12_certificate = OpenSSL::PKCS12.new(File.read(CERTIFICATE), CERTIFICATE_PASSWORD)
-      intermediate_certificate = OpenSSL::X509::Certificate.new(File.read(INTERMEDIATE_CERTIFICATE))
+      p12_certificate = OpenSSL::PKCS12.new(File.read(certificate_path), Passkit.configuration.certificate_key)
+      intermediate_certificate = OpenSSL::X509::Certificate.new(File.read(intermediate_certificate_path))
 
       flag = OpenSSL::PKCS7::DETACHED | OpenSSL::PKCS7::BINARY
       signed = OpenSSL::PKCS7.sign(p12_certificate.certificate,

--- a/lib/passkit/url_generator.rb
+++ b/lib/passkit/url_generator.rb
@@ -3,7 +3,7 @@ module Passkit
     include Passkit::Engine.routes.url_helpers
 
     def initialize(pass_class, generator = nil, collection_name = nil)
-      @url = passes_api_url(host: ENV["PASSKIT_WEB_SERVICE_HOST"],
+      @url = passes_api_url(host: Passkit.configuration.web_service_host,
         payload: PayloadGenerator.encrypted(pass_class, generator, collection_name))
     end
 


### PR DESCRIPTION
Hi @coorasse,

we just started using your gem in our Rails app, it's working great, so thank you, first of all!

We ran into a bit of trouble deploying this, though. If any of the required env variables is not set, not only will the gem not work (expected and acceptable), but the rails app will fail to start (not so good 😁 ).

This PR adds a couple of configuration changes, and might help addressing both #34 and #5.

* A configuration option for the check on required configuration attributes (defaults to `true`, so no behaviour change on upgrade, it must be set to `false` explicitly in an initializer)
* Replaced the use of all env variables with the equivalent configuration option - they're already assigned from env vars on startup, so might as well use them. This allows users to configure the gem completely from within an initalizer, with env variables or other mechanisms like Rails secrets. 

Tests are still passing, but I didn't add any new ones since I'm more familiar with rspec and a bit short on time right now. Happy to amend that sometime later if needed.

Cheers,
Thilo