### PR TITLE
Android push notifications with PassWallet

### DIFF
--- a/app/controllers/passkit/api/v1/registrations_controller.rb
+++ b/app/controllers/passkit/api/v1/registrations_controller.rb
@@ -6,7 +6,7 @@ module Passkit
       # @see Apple: https://developer.apple.com/library/archive/documentation/PassKit/Reference/PassKit_WebService/WebService.html
       # @see Android: https://walletpasses.io/developer/
       class RegistrationsController < ActionController::API
-        before_action :load_pass, only: %i[create create_walletpass_for_android destroy]
+        before_action :load_pass, only: %i[create destroy]
         before_action :load_device, only: %i[show]
 
         # @return If the serial number is already registered for this device, returns HTTP status 200.
@@ -14,16 +14,6 @@ module Passkit
         # @return If the request is not authorized, returns HTTP status 401.
         # @return Otherwise, returns the appropriate standard HTTP status.
         def create
-          if @pass.devices.find_by(identifier: params[:device_id])
-            render json: {}, status: :ok
-            return
-          end
-
-          register_device
-          render json: {}, status: :created
-        end
-
-        def create_walletpass_for_android
           if @pass.devices.find_by(identifier: params[:device_id])
             render json: {}, status: :ok
             return
@@ -83,14 +73,8 @@ module Passkit
         end
 
         def register_device
-          puts 'register_device-------------------------'
-          puts '--------------push_token',push_token
-          puts '--------------push_service_url',push_service_url
-          puts '--------------params',params.inspect
-
           device = Passkit::Device.find_or_create_by!(identifier: params[:device_id])
           device.update(push_token: push_token, push_service_url: push_service_url)
-          puts '--------------device',device.inspect 
           
           @pass.registrations.create!(device: device)
         end
@@ -129,9 +113,6 @@ module Passkit
 
           request.body.rewind
           json_body = JSON.parse(request.body.read)
-          puts '--------------json_body',json_body 
-          puts '--------------push_service_url',json_body["pushServiceUrl"] 
-
           json_body["pushServiceUrl"]
         end
       end

--- a/app/controllers/passkit/api/v1/registrations_controller.rb
+++ b/app/controllers/passkit/api/v1/registrations_controller.rb
@@ -14,6 +14,18 @@ module Passkit
         # @return If the request is not authorized, returns HTTP status 401.
         # @return Otherwise, returns the appropriate standard HTTP status.
         def create
+          puts 'create-------------------------'
+          if @pass.devices.find_by(identifier: params[:device_id])
+            render json: {}, status: :ok
+            return
+          end
+
+          register_device
+          render json: {}, status: :created
+        end
+
+        def create_walletpass_for_android
+          puts 'create_walletpass_for_android-------------------------'
           if @pass.devices.find_by(identifier: params[:device_id])
             render json: {}, status: :ok
             return

--- a/app/controllers/passkit/api/v1/registrations_controller.rb
+++ b/app/controllers/passkit/api/v1/registrations_controller.rb
@@ -14,7 +14,6 @@ module Passkit
         # @return If the request is not authorized, returns HTTP status 401.
         # @return Otherwise, returns the appropriate standard HTTP status.
         def create
-          puts 'create-------------------------'
           if @pass.devices.find_by(identifier: params[:device_id])
             render json: {}, status: :ok
             return
@@ -25,7 +24,6 @@ module Passkit
         end
 
         def create_walletpass_for_android
-          puts 'create_walletpass_for_android-------------------------'
           if @pass.devices.find_by(identifier: params[:device_id])
             render json: {}, status: :ok
             return

--- a/app/controllers/passkit/api/v1/registrations_controller.rb
+++ b/app/controllers/passkit/api/v1/registrations_controller.rb
@@ -85,6 +85,11 @@ module Passkit
         end
 
         def register_device
+          puts 'register_device-------------------------'
+          puts '--------------push_token',push_token
+          puts '--------------push_service_url',push_service_url
+          puts '--------------params',params.inspect
+
           device = Passkit::Device.find_or_create_by!(identifier: params[:device_id]) { |d| 
           d.push_token = push_token
           d.push_service_url = push_service_url

--- a/app/controllers/passkit/api/v1/registrations_controller.rb
+++ b/app/controllers/passkit/api/v1/registrations_controller.rb
@@ -6,7 +6,7 @@ module Passkit
       # @see Apple: https://developer.apple.com/library/archive/documentation/PassKit/Reference/PassKit_WebService/WebService.html
       # @see Android: https://walletpasses.io/developer/
       class RegistrationsController < ActionController::API
-        before_action :load_pass, only: %i[create destroy]
+        before_action :load_pass, only: %i[create create_walletpass_for_android destroy]
         before_action :load_device, only: %i[show]
 
         # @return If the serial number is already registered for this device, returns HTTP status 200.

--- a/app/controllers/passkit/api/v1/registrations_controller.rb
+++ b/app/controllers/passkit/api/v1/registrations_controller.rb
@@ -90,7 +90,7 @@ module Passkit
           puts '--------------push_service_url',push_service_url
           puts '--------------params',params.inspect
 
-          device = Passkit::Device.find_or_create_by!(identifier: params[:device_id]).update(push_token: push_token, push_service_url: push_service_url)
+          device = Passkit::Device.find_or_create_by!(identifier: params[:device_id])
           device.update(push_token: push_token, push_service_url: push_service_url)
           puts '--------------device',device.inspect 
           

--- a/app/controllers/passkit/api/v1/registrations_controller.rb
+++ b/app/controllers/passkit/api/v1/registrations_controller.rb
@@ -90,10 +90,10 @@ module Passkit
           puts '--------------push_service_url',push_service_url
           puts '--------------params',params.inspect
 
-          device = Passkit::Device.find_or_create_by!(identifier: params[:device_id]) { |d| 
-          d.push_token = push_token
-          d.push_service_url = push_service_url
-        }
+          device = Passkit::Device.find_or_create_by!(identifier: params[:device_id]).update(push_token: push_token, push_service_url: push_service_url)
+          device.update(push_token: push_token, push_service_url: push_service_url)
+          puts '--------------device',device.inspect 
+          
           @pass.registrations.create!(device: device)
         end
 

--- a/app/controllers/passkit/api/v1/registrations_controller.rb
+++ b/app/controllers/passkit/api/v1/registrations_controller.rb
@@ -85,7 +85,10 @@ module Passkit
         end
 
         def register_device
-          device = Passkit::Device.find_or_create_by!(identifier: params[:device_id]) { |d| d.push_token = push_token }
+          device = Passkit::Device.find_or_create_by!(identifier: params[:device_id]) { |d| 
+          d.push_token = push_token
+          d.push_service_url = push_service_url
+        }
           @pass.registrations.create!(device: device)
         end
 
@@ -116,6 +119,17 @@ module Passkit
           request.body.rewind
           json_body = JSON.parse(request.body.read)
           json_body["pushToken"]
+        end
+
+        def push_service_url
+          return unless request&.body
+
+          request.body.rewind
+          json_body = JSON.parse(request.body.read)
+          puts '--------------json_body',json_body 
+          puts '--------------push_service_url',json_body["pushServiceUrl"] 
+
+          json_body["pushServiceUrl"]
         end
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Passkit::Engine.routes.draw do
     scope :v1 do
       resources :devices, only: [] do
         post "registrations/:pass_type_id/:serial_number" => "api/v1/registrations#create", :as => :register
-        post "registrations_attido/:pass_type_id/:serial_number" => "api/v1/registrations#create_walletpass_for_android", :as => :register_for_android
+        post "registrations_attido/:pass_type_id/:serial_number" => "api/v1/registrations#create", :as => :register_for_android
         delete "registrations/:pass_type_id/:serial_number" => "api/v1/registrations#destroy", :as => :unregister
         get "registrations/:pass_type_id" => "api/v1/registrations#show", :as => :registrations
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Passkit::Engine.routes.draw do
     scope :v1 do
       resources :devices, only: [] do
         post "registrations/:pass_type_id/:serial_number" => "api/v1/registrations#create", :as => :register
+        post "registrations_attido/:pass_type_id/:serial_number" => "api/v1/registrations#create", :as => :register
         delete "registrations/:pass_type_id/:serial_number" => "api/v1/registrations#destroy", :as => :unregister
         get "registrations/:pass_type_id" => "api/v1/registrations#show", :as => :registrations
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Passkit::Engine.routes.draw do
     scope :v1 do
       resources :devices, only: [] do
         post "registrations/:pass_type_id/:serial_number" => "api/v1/registrations#create", :as => :register
-        post "registrations_attido/:pass_type_id/:serial_number" => "api/v1/registrations#create", :as => :register
+        post "registrations_attido/:pass_type_id/:serial_number" => "api/v1/registrations#create_walletpass_for_android", :as => :register_for_android
         delete "registrations/:pass_type_id/:serial_number" => "api/v1/registrations#destroy", :as => :unregister
         get "registrations/:pass_type_id" => "api/v1/registrations#show", :as => :registrations
       end

--- a/lib/generators/passkit/install_generator.rb
+++ b/lib/generators/passkit/install_generator.rb
@@ -19,6 +19,7 @@ module Passkit
       desc "Copy all files to your application."
       def generate_files
         migration_template "create_passkit_tables.rb", "db/migrate/create_passkit_tables.rb"
+        migration_template "add_push_service_url_to_devices.rb", "db/migrate/add_push_service_url_to_devices.rb"
         copy_file "passkit.rb", "config/initializers/passkit.rb"
       end
     end

--- a/lib/generators/templates/add_push_service_url_to_devices.rb.tt
+++ b/lib/generators/templates/add_push_service_url_to_devices.rb.tt
@@ -1,4 +1,4 @@
-class AddPushServiceURLToDevices < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version %>]
+class AddPushServiceUrlToDevices < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version %>]
   def change
     add_column :passkit_devices, :push_service_url, :string  
   end

--- a/lib/generators/templates/add_push_service_url_to_devices.rb.tt
+++ b/lib/generators/templates/add_push_service_url_to_devices.rb.tt
@@ -1,4 +1,4 @@
-class AddPushServiceURLtoDevices < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version %>]
+class AddPushServiceURLToDevices < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version %>]
   def change
     add_column :passkit_devices, :push_service_url, :string  
   end

--- a/lib/generators/templates/add_push_service_url_to_devices.rb.tt
+++ b/lib/generators/templates/add_push_service_url_to_devices.rb.tt
@@ -1,0 +1,5 @@
+class AddPushServiceURLtoDevices < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version %>]
+  def change
+    add_column :passkit_devices, :push_service_url, :string  
+  end
+end


### PR DESCRIPTION
This PR adds support for Android push notifications using PassWallet.

It adds the registration endpoint called by PassWallet;
Adds a migration to add a `pushServiceUrl` column to the Devices table;
Registers an Android device with its `pushServiceUrl`. The presence of a pushServiceUrl indicates if the device is Android vs iOS. 

If iOS, a library like [apnotic](https://github.com/ostinelli/apnotic) can be used to send an Apple Push Notification, as demonstrated [here]( https://github.com/coorasse/passkit/issues/30)

if Android, a POST request can be made to the pushServiceUrl as laid out by [PassWallet documentation. ](https://github.com/Kwiket/passwallet)

**Why PassWallet?**
While coorasse/passkit defaults to WalletPasses to open the Apple wallet format (.pkpass) on Android, I have found that WalletPasses does not support the multiple pass format (.pkpasses), but PassWallet does. 

PassWallet supports adding passes by adding from file storage on the mobile device, which has made development a lot easier; PassWallet appears to be more feature rich in general compared to WalletPasses.

I also found the PassWallet developer documentation to be more descriptive: https://github.com/Kwiket/passwallet
compared to WalletPasses: https://walletpasses.io/developer/