### PR TITLE
Add note regarding pass type identifier

### DIFF
--- a/docs/passkit_environment_variables.md
+++ b/docs/passkit_environment_variables.md
@@ -32,6 +32,9 @@ Head to your Apple Developers console and generate a new certificate.
 
 The identifier is the `PASSKIT_PASS_TYPE_IDENTIFIER` variable.
 
+**Note**: When renewing your certificate, make sure that this identifier stays the same as before. Changing this identifier will
+require existing passes to be regenerated, as they will otherwise no longer be updateable via the web service URL.
+
 Now, create a certificate signing request: https://developer.apple.com/help/account/create-certificates/create-a-certificate-signing-request/
 
 And create the certificate:


### PR DESCRIPTION
I believe it's important to note that, when regenerating the passkit certificate, the pass type identifier should remain the same as before.

I wasn't fully aware of it and went ahead and changed it, which caused the previously generated passes to fail on the next update due to a type mismatch.